### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # OCP News Plugin
 
-allows OCP to play urls for some news providers, this plugin will extract the real stream at playback time
+This plugin lets [OCP](https://github.com/OpenVoiceOS/ovos-media) play news feeds from several providers. It resolves a news request to the real stream URL and hands it to OCP for playback.
+
+## Install
+
+```bash
+pip install ovos-ocp-news-plugin
+```
+
+## Usage
+
+OCP loads this plugin through the `opm.ocp.extractor` entry point. It handles two kinds of stream requests:
+
+- A URI with the `news//` prefix, for example `news//georgia-today`.
+- A URI that starts with one of the news provider URLs the plugin recognizes (for example a TSF or NPR feed URL).
+
+No manual setup is needed beyond installing the plugin. OCP settings for this plugin live under the `news` key in `mycroft.conf`. The plugin defines no settings of its own.
+
+## Related projects
+
+- [OpenVoiceOS/ovos-media](https://github.com/OpenVoiceOS/ovos-media): the OCP media player that loads this extractor.
+- [OpenVoiceOS/ovos-ocp-rss-plugin](https://github.com/OpenVoiceOS/ovos-ocp-rss-plugin): extracts streams from RSS and podcast feeds. Several news sources here resolve through it.
+- [OpenVoiceOS/ovos-ocp-m3u-plugin](https://github.com/OpenVoiceOS/ovos-ocp-m3u-plugin): extracts streams from M3U playlists.
+- [OpenVoiceOS/ovos-ocp-audio-plugin](https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin): a sibling OCP stream extractor plugin.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README for clarity, expands it from a one-line description into install/usage/related-projects sections, and adds links to sibling OCP extractor plugins.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation instructions.
  * Documented supported request formats and configuration options.
  * Added information about related projects and the Apache-2.0 license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->